### PR TITLE
Revise header branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Trade Log — Stocks & Options</title>
+  <title>Trading cards: because the house always wins</title>
   <meta name="description" content="Local-first trading log for stocks and options. Import/export JSON. No data leaves your device." />
   <style>
     :root {
@@ -43,15 +43,14 @@
       backdrop-filter: saturate(130%) blur(6px);
       border-bottom: 2px solid var(--ink);
     }
-    .bar { display: grid; grid-template-columns: 64px 1fr auto; gap: 16px; align-items: center; padding: 12px 0; }
+    .bar { display: grid; grid-template-columns: 80px 1fr auto; gap: 16px; align-items: center; padding: 12px 0; }
     .logo {
-      width: 56px;
-      height: 56px;
-      border-radius: 16px;
+      width: 72px;
+      height: 72px;
+      border-radius: 18px;
       background: var(--panel);
       display: grid;
       place-items: center;
-      border: 2px solid var(--ink);
       overflow: hidden;
     }
     .logo img {
@@ -142,7 +141,7 @@
         <img src="logo_small.png" srcset="logo_small.png 1x, logo.png 2x" alt="Trade Log logo" />
       </div>
       <div>
-        <div style="font-weight: 700; font-size: 18px;">Trade Log — Stocks & Options</div>
+        <div style="font-weight: 700; font-size: 18px;">Trading cards: because the house always wins</div>
       </div>
       <div class="metrics">
         <div class="metric" id="metric-equity">Total equity: $0.00</div>


### PR DESCRIPTION
## Summary
- update the application title to the new "Trading cards" catchphrase
- enlarge the header logo and remove its outline while widening the layout column

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97d48e53c8325b2261577ec3cb545