### PR TITLE
Adjust header color and enlarge logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,16 +39,16 @@
     .container { max-width: 1100px; margin: 0 auto; padding: 16px; }
     header {
       position: sticky; top: 0; z-index: 5;
-      background: linear-gradient(180deg, rgba(255, 253, 248, 0.95) 0%, rgba(247, 239, 227, 0.9) 100%);
+      background: rgb(240, 232, 207);
       backdrop-filter: saturate(130%) blur(6px);
       border-bottom: 2px solid var(--ink);
     }
-    .bar { display: grid; grid-template-columns: 80px 1fr auto; gap: 16px; align-items: center; padding: 12px 0; }
+    .bar { display: grid; grid-template-columns: 96px 1fr auto; gap: 16px; align-items: center; padding: 12px 0; }
     .logo {
-      width: 72px;
-      height: 72px;
-      border-radius: 18px;
-      background: var(--panel);
+      width: 86px;
+      height: 86px;
+      border-radius: 22px;
+      background: rgb(240, 232, 207);
       display: grid;
       place-items: center;
       overflow: hidden;


### PR DESCRIPTION
## Summary
- update the sticky header to use an RGB(240, 232, 207) background that complements the logo artwork
- expand the logo container by roughly 20% and adjust the grid column to accommodate the new size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97f46e9088325829a947f76337bff