### PR TITLE
Reduce trading card footprint

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,32 +93,33 @@
     .group-header { display: flex; align-items: center; justify-content: space-between; margin: 18px 0 8px; padding: 10px 14px; border: 2px solid var(--ink); border-radius: var(--radius-sm); background: var(--panel-2); }
     .group-title { font-weight: 700; color: var(--muted); letter-spacing: 0.02em; }
 
-    .cards { display: grid; grid-template-columns: 1fr; gap: 10px; }
+    .cards { display: grid; grid-template-columns: 1fr; gap: 8px; }
     @media (min-width: 720px) { .cards { grid-template-columns: 1fr 1fr; } }
-    .card { border: 2px solid var(--ink); border-radius: var(--radius); background: var(--panel); padding: 16px; display: grid; gap: 10px; }
-    .card-header { display: flex; align-items: baseline; justify-content: space-between; }
-    .chip { background: var(--accent-2); border: 2px solid var(--ink-dark); padding: 3px 10px; border-radius: 999px; font-size: 12px; color: #2f4f4b; }
+    .card { border: 2px solid var(--ink); border-radius: var(--radius); background: var(--panel); padding: 12px; display: grid; gap: 8px; font-size: 14px; }
+    .card-header { display: flex; align-items: baseline; justify-content: space-between; gap: 6px; }
+    .card-header .muted { font-size: 12px; }
+    .chip { background: var(--accent-2); border: 2px solid var(--ink-dark); padding: 2px 8px; border-radius: 999px; font-size: 11px; color: #2f4f4b; }
     .rating-badge {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: 4px 8px;
+      padding: 3px 6px;
       border-radius: var(--radius-sm);
       border: 2px solid var(--ink);
       background: var(--panel-2);
-      font-size: 26px;
+      font-size: 20px;
       line-height: 1;
     }
     .bad { color: var(--danger); font-weight: 600; }
     .good { color: var(--success); font-weight: 600; }
     .warn { color: var(--warn); font-weight: 600; }
     .muted { color: var(--muted); }
-    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-    .row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; }
-    .kv { background: var(--panel-2); border: 2px solid var(--ink); border-radius: var(--radius-sm); padding: 10px; font-size: 13px; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+    .row-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+    .kv { background: var(--panel-2); border: 2px solid var(--ink); border-radius: var(--radius-sm); padding: 8px; font-size: 12px; }
     .kv b { color: var(--text); font-weight: 700; }
-    .note { font-size: 13px; color: var(--muted); background: var(--panel-2); border: 2px solid var(--ink); padding: 10px; border-radius: var(--radius-sm); }
-    .actions { display: flex; gap: 6px; justify-content: flex-end; }
+    .note { font-size: 12px; color: var(--muted); background: var(--panel-2); border: 2px solid var(--ink); padding: 8px; border-radius: var(--radius-sm); }
+    .actions { display: flex; gap: 4px; justify-content: flex-end; }
 
     .footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 24px 0 40px; color: var(--muted); font-size: 12px; }
 


### PR DESCRIPTION
## Summary
- reduce the card grid spacing and padding to shrink each trading card
- decrease type scales and badge sizing within cards for a more compact layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98112e378832584b400aae4887aa4