### PR TITLE
Update dashboard equity labels and enlarge logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
     }
     .bar { display: grid; grid-template-columns: 96px 1fr auto; gap: 16px; align-items: center; padding: 12px 0; }
     .logo {
-      width: 86px;
-      height: 86px;
+      width: 103px;
+      height: 103px;
       border-radius: 22px;
       background: rgb(240, 232, 207);
       display: grid;
@@ -145,8 +145,8 @@
         <div style="font-weight: 700; font-size: 18px;">Trading cards: collect, reflect, correct.</div>
       </div>
       <div class="metrics">
-        <div class="metric" id="metric-equity">Total equity: $0.00</div>
-        <div class="metric" id="metric-exposure">Current exposure: $0.00</div>
+        <div class="metric" id="metric-equity">Equity: $0.00</div>
+        <div class="metric" id="metric-exposure">Exposure: $0.00</div>
       </div>
     </div>
     <div class="container toolbar">
@@ -417,8 +417,8 @@
       if (t.sellTime && derived.netReturn !== null) totalEquity += derived.netReturn;
       if (!t.sellTime) exposure += derived.netCost;
     }
-    metricEquity.textContent = `Total equity: ${currency(totalEquity)}`;
-    metricExposure.textContent = `Current exposure: ${currency(exposure)}`;
+    metricEquity.textContent = `Equity: ${currency(totalEquity)}`;
+    metricExposure.textContent = `Exposure: ${currency(exposure)}`;
   }
 
   function normalizeForSearch(s) { return (s || '').toLowerCase(); }


### PR DESCRIPTION
## Summary
- rename the top bar metrics to "Equity" and "Exposure" to simplify the labels
- enlarge the header logo by 20% for improved visual balance

## Testing
- not run (static asset change)


------
https://chatgpt.com/codex/tasks/task_e_68d981f519908325afc4c0518db54a30