### PR TITLE
Use pencil icon for card edit button

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,7 +556,11 @@
     }
 
     const actions = document.createElement('div'); actions.className = 'actions';
-    const edit = document.createElement('button'); edit.textContent = 'Edit'; edit.addEventListener('click', () => openModal(t.id));
+    const edit = document.createElement('button');
+    edit.textContent = '✏️';
+    edit.setAttribute('aria-label', 'Edit');
+    edit.title = 'Edit';
+    edit.addEventListener('click', () => openModal(t.id));
     actions.appendChild(edit);
     card.appendChild(actions);
     return card;


### PR DESCRIPTION
## Summary
- replace the card edit button label with a pencil emoji while keeping accessibility labels

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d982d3b0b48325bb2ba98f477a99b9