### PR TITLE
Enable double-click editing for trade cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,8 +119,6 @@
     .kv { background: var(--panel-2); border: 2px solid var(--ink); border-radius: var(--radius-sm); padding: 8px; font-size: 12px; }
     .kv b { color: var(--text); font-weight: 700; }
     .note { font-size: 12px; color: var(--muted); background: var(--panel-2); border: 2px solid var(--ink); padding: 8px; border-radius: var(--radius-sm); }
-    .actions { display: flex; gap: 4px; justify-content: flex-end; }
-
     .footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 24px 0 40px; color: var(--muted); font-size: 12px; }
 
     dialog[open] { border: 2px solid var(--ink); border-radius: 20px; background: var(--panel); color: var(--text); width: min(740px, 96vw); }
@@ -555,14 +553,7 @@
       const n = document.createElement('div'); n.className='note'; n.textContent = t.notes; card.appendChild(n);
     }
 
-    const actions = document.createElement('div'); actions.className = 'actions';
-    const edit = document.createElement('button');
-    edit.textContent = '✏️';
-    edit.setAttribute('aria-label', 'Edit');
-    edit.title = 'Edit';
-    edit.addEventListener('click', () => openModal(t.id));
-    actions.appendChild(edit);
-    card.appendChild(actions);
+    card.addEventListener('dblclick', () => openModal(t.id));
     return card;
   }
 


### PR DESCRIPTION
## Summary
- remove the per-card pencil edit button
- open the trade edit modal when a card is double-clicked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9850fd2448325ae6f7c27511c43f8