### PR TITLE
Style footer data notice as panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,22 @@
     .kv { background: var(--panel-2); border: 2px solid var(--ink); border-radius: var(--radius-sm); padding: 8px; font-size: 12px; }
     .kv b { color: var(--text); font-weight: 700; }
     .note { font-size: 12px; color: var(--muted); background: var(--panel-2); border: 2px solid var(--ink); padding: 8px; border-radius: var(--radius-sm); }
-    .footer { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 24px 0 40px; color: var(--muted); font-size: 12px; }
+    .footer { margin: 24px 0 40px; color: var(--muted); font-size: 12px; }
+    .footer-panel {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 12px;
+      align-items: center;
+      padding: 14px 18px;
+      background: var(--panel-2);
+      border: 2px solid var(--ink);
+      border-radius: var(--radius);
+      box-shadow: 0 6px 16px -10px var(--shadow);
+    }
+    @media (max-width: 540px) {
+      .footer-panel { grid-template-columns: 1fr; justify-items: stretch; }
+      .footer-panel button { justify-self: start; }
+    }
 
     dialog[open] { border: 2px solid var(--ink); border-radius: 20px; background: var(--panel); color: var(--text); width: min(740px, 96vw); }
     .modal-head { display: flex; align-items: center; justify-content: space-between; padding: 12px 18px; border-bottom: 2px solid var(--ink); font-weight: 700; }
@@ -178,8 +193,10 @@
   <main class="container" id="app" style="margin-top: 16px;"></main>
 
   <div class="container footer">
-    <div>We don't collect or store any data. Everything happens on your device.</div>
-    <button class="danger" id="clearBtn">Clear stored data</button>
+    <div class="footer-panel">
+      <div>We don't collect or store any data. Everything happens on your device.</div>
+      <button class="danger" id="clearBtn">Clear stored data</button>
+    </div>
   </div>
 
   <dialog id="tradeModal">


### PR DESCRIPTION
## Summary
- restyle the footer data notice and clear button inside a panel with matching border, radius, and background
- ensure the footer layout adapts on narrow viewports so the button wraps beneath the message

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9868a4830832583c487bb7710e25b