### PR TITLE
Update README with project overview and smaller logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # Tradejournal
 
-![Tradejournal logo](logo.png)
+<p align="center">
+  <img src="logo.png" alt="Tradejournal logo" width="96" />
+</p>
+
+Tradejournal is a lightweight web-based journal designed to help traders reflect on their decisions and learn from past performance. The project showcases a clean interface that highlights individual trades, key metrics, and personal notes. By reviewing trends and outcomes at a glance, users can quickly spot patterns that may improve their strategy.
+
+The app is built as a static site, so you can host it on any simple web server or deploy it through GitHub Pages. Customize the included `data.json` file with your own trade history to instantly tailor the experience to your needs. The included screenshot below illustrates the layout and visual style of the dashboard.
 
 ![Tradejournal screenshot](screenshot.png)
 
-[MIT License](LICENSE)
+## Getting Started
+
+1. Clone the repository and open `index.html` in your browser to explore the sample journal.
+2. Update `data.json` with your trade entries to populate the dashboard with personalized content.
+3. Adjust the styling or layout in `index.html` to match your preferred branding.
+
+## License
+
+This project is released under the [MIT License](LICENSE). Feel free to adapt it for personal or commercial use.


### PR DESCRIPTION
## Summary
- expand the README with a fuller project description, onboarding guidance, and licensing notes
- shrink the displayed logo to a small "postage stamp" size using an HTML image tag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d99ce35e048325bee52afdceac5fcf