### PR TITLE
Make calendar view default grouping

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@
           <option value="-rating">Rating (best first)</option>
         </select>
         <select id="groupBy" title="Group">
+          <option value="day" selected>Group: Day</option>
           <option value="none">Group: None</option>
-          <option value="day">Group: Day</option>
           <option value="week">Group: Week</option>
         </select>
       </div>


### PR DESCRIPTION
## Summary
- set the "Group" selector to default to the calendar-friendly day view so the calendar loads first

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da6365351483258b318be0c3191ddf